### PR TITLE
Minor spelling mistake

### DIFF
--- a/docs/multiblocked2/KubeJS/recipe.md
+++ b/docs/multiblocked2/KubeJS/recipe.md
@@ -1,6 +1,6 @@
 # Recipe Creation
 
-Add reipces to the recipe type (`id = mbd2:blender`).
+Add recipes to the recipe type (`id = mbd2:blender`).
 
 ```javascript
 // server script


### PR DESCRIPTION
Fixes a spelling error in on the MBD2 kubejs recipe page. That's it.

![minor-spelling-mistake](https://github.com/user-attachments/assets/29c1ac59-3cff-42d1-bd9c-06cda100a1e5)
